### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     edstan, 
     ggplot2,
@@ -36,8 +36,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 Suggests: 
     knitr,

--- a/inst/stan/UM4nocov.stan
+++ b/inst/stan/UM4nocov.stan
@@ -32,9 +32,9 @@ data {
   int<lower=1> I_po;
   int<lower=1> I_NN;
   int<lower=0> N_mis;
-  int<lower=1, upper=I> II[N];
-  int<lower=1, upper=J> JJ[N];
-  int<lower=0, upper=6> y[N];
+  array[N] int<lower=1, upper=I> II;
+  array[N] int<lower=1, upper=J> JJ;
+  array[N] int<lower=0, upper=6> y;
 
   // user-defined priors
   real ma;
@@ -47,7 +47,7 @@ data {
   real vt;
 
   int<lower=1,upper=I>trait;
-  int<lower=1,upper=I>ind[N];
+  array[N] int<lower=1,upper=I>ind;
   vector[trait] theta_mu;
 }
 
@@ -57,9 +57,9 @@ parameters {
   vector<lower=0,upper=5>[I_po]   delta_po;
   vector<lower=-5,upper=0>[I_ne]  delta_ng;
   vector<lower=-5,upper=5>[I_nu]  delta_nu;
-  vector<lower=-5,upper=0>[K-1]   tau_raw[I];
+  array[I] vector<lower=-5,upper=0>[K-1]   tau_raw;
 
-  vector[trait] theta[J];
+  array[J] vector[trait] theta;
   cholesky_factor_corr[trait] L_Omega;
 }
 
@@ -67,7 +67,7 @@ transformed parameters{
 
   vector[I_NN] delta1;
   vector[I] delta;
-  vector[K] tau[I];
+  array[I] vector[K] tau;
 
   delta1=append_row(delta_ng,delta_nu);
   delta=append_row(delta1,delta_po);

--- a/inst/stan/UM4withcov.stan
+++ b/inst/stan/UM4withcov.stan
@@ -32,9 +32,9 @@ data {
   int<lower=1> I_po;
   int<lower=1> I_NN;
   int<lower=0> N_mis;
-  int<lower=1, upper=I> II[N];
-  int<lower=1, upper=J> JJ[N];
-  int<lower=0, upper=6> y[N];
+  array[N] int<lower=1, upper=I> II;
+  array[N] int<lower=1, upper=J> JJ;
+  array[N] int<lower=0, upper=6> y;
 
   // user-defined priors
   real ma;
@@ -47,7 +47,7 @@ data {
   real vt;
 
   int<lower=1,upper=I>trait;
-  int<lower=1,upper=I>ind[N];
+  array[N] int<lower=1,upper=I>ind;
   vector[trait] theta_mu;
   int<lower=1> P;
   matrix[trait*J,P] PC1;
@@ -59,9 +59,9 @@ parameters {
   vector<lower=0,upper=5>[I_po]   delta_po;
   vector<lower=-5,upper=0>[I_ne]  delta_ng;
   vector<lower=-5,upper=5>[I_nu]  delta_nu;
-  vector<lower=-5,upper=0>[K-1]   tau_raw[I];
+  array[I] vector<lower=-5,upper=0>[K-1]   tau_raw;
 
-  vector[trait] theta[J];
+  array[J] vector[trait] theta;
   cholesky_factor_corr[trait] L_Omega;
   matrix[P,trait] lambda;    // person covariate regression coefficient
 }
@@ -70,7 +70,7 @@ transformed parameters{
 
   vector[I_NN] delta1;
   vector[I] delta;
-  vector[K] tau[I];
+  array[I] vector[K] tau;
 
   delta1=append_row(delta_ng,delta_nu);
   delta=append_row(delta1,delta_po);

--- a/inst/stan/UM7nocov.stan
+++ b/inst/stan/UM7nocov.stan
@@ -32,9 +32,9 @@ data {
   int<lower=1> I_po;
   int<lower=1> I_NN;
   int<lower=0> N_mis;
-  int<lower=1, upper=I> II[N];
-  int<lower=1, upper=J> JJ[N];
-  int<lower=0, upper=6> y[N];
+  array[N] int<lower=1, upper=I> II;
+  array[N] int<lower=1, upper=J> JJ;
+  array[N] int<lower=0, upper=6> y;
 
   // user-defined priors
   real ma;
@@ -47,7 +47,7 @@ data {
   real vt;
 
   int<lower=1,upper=I>trait;
-  int<lower=1,upper=I>ind[N];
+  array[N] int<lower=1,upper=I>ind;
   vector[trait] theta_mu;
 }
 
@@ -59,7 +59,7 @@ parameters {
   vector<lower=-5,upper=5>[I_nu]  delta_nu;
   vector<lower=-5,upper=0>[K-1]   tau_raw;
 
-  vector[trait] theta[J];
+  array[J] vector[trait] theta;
   cholesky_factor_corr[trait] L_Omega;
 }
 

--- a/inst/stan/UM7withcov.stan
+++ b/inst/stan/UM7withcov.stan
@@ -32,9 +32,9 @@ data {
   int<lower=1> I_po;
   int<lower=1> I_NN;
   int<lower=0> N_mis;
-  int<lower=1, upper=I> II[N];
-  int<lower=1, upper=J> JJ[N];
-  int<lower=0, upper=6> y[N];
+  array[N] int<lower=1, upper=I> II;
+  array[N] int<lower=1, upper=J> JJ;
+  array[N] int<lower=0, upper=6> y;
 
   // user-defined priors
   real ma;
@@ -47,7 +47,7 @@ data {
   real vt;
 
   int<lower=1,upper=I>trait;
-  int<lower=1,upper=I>ind[N];
+  array[N] int<lower=1,upper=I>ind;
   vector[trait] theta_mu;
   int<lower=1> P;
   matrix[trait*J,P] PC1;
@@ -61,7 +61,7 @@ parameters {
   vector<lower=-5,upper=5>[I_nu]  delta_nu;
   vector<lower=-5,upper=0>[K-1]   tau_raw;
 
-  vector[trait] theta[J];
+  array[J] vector[trait] theta;
   cholesky_factor_corr[trait] L_Omega;
   matrix[P,trait] lambda;    // person covariate regression coefficient
 }

--- a/inst/stan/UM8nocov.stan
+++ b/inst/stan/UM8nocov.stan
@@ -32,9 +32,9 @@ data {
   int<lower=0> I_po;
   int<lower=1> I_NN;
   int<lower=0> N_mis;
-  int<lower=1, upper=I> II[N];
-  int<lower=1, upper=J> JJ[N];
-  int<lower=0, upper=6> y[N];
+  array[N] int<lower=1, upper=I> II;
+  array[N] int<lower=1, upper=J> JJ;
+  array[N] int<lower=0, upper=6> y;
 
   // user-defined priors
   real ma;
@@ -47,7 +47,7 @@ data {
   real vt;
 
   int<lower=1,upper=I>trait;
-  int<lower=1,upper=I>ind[N];
+  array[N] int<lower=1,upper=I>ind;
   vector[trait] theta_mu;
 }
 
@@ -57,9 +57,9 @@ parameters {
   vector<lower=0,upper=5>[I_po]   delta_po;
   vector<lower=-5,upper=0>[I_ne]  delta_ng;
   vector<lower=-5,upper=5>[I_nu]  delta_nu;
-  vector<lower=-5,upper=0>[K-1]   tau_raw[I];
+  array[I] vector<lower=-5,upper=0>[K-1]   tau_raw;
 
-  vector[trait] theta[J];
+  array[J] vector[trait] theta;
   cholesky_factor_corr[trait] L_Omega;
 }
 
@@ -67,7 +67,7 @@ transformed parameters{
 
   vector[I_NN] delta1;
   vector[I] delta;
-  vector[K] tau[I];
+  array[I] vector[K] tau;
 
   delta1=append_row(delta_ng,delta_nu);
   delta=append_row(delta1,delta_po);

--- a/inst/stan/UM8withcov.stan
+++ b/inst/stan/UM8withcov.stan
@@ -32,9 +32,9 @@ data {
   int<lower=1> I_po;
   int<lower=1> I_NN;
   int<lower=0> N_mis;
-  int<lower=1, upper=I> II[N];
-  int<lower=1, upper=J> JJ[N];
-  int<lower=0, upper=6> y[N];
+  array[N] int<lower=1, upper=I> II;
+  array[N] int<lower=1, upper=J> JJ;
+  array[N] int<lower=0, upper=6> y;
 
   // user-defined priors
   real ma;
@@ -47,7 +47,7 @@ data {
   real vt;
 
   int<lower=1,upper=I>trait;
-  int<lower=1,upper=I>ind[N];
+  array[N] int<lower=1,upper=I>ind;
   vector[trait] theta_mu;
   int<lower=1> P;
   matrix[trait*J,P] PC1;
@@ -59,9 +59,9 @@ parameters {
   vector<lower=0,upper=5>[I_po]   delta_po;
   vector<lower=-5,upper=0>[I_ne]  delta_ng;
   vector<lower=-5,upper=5>[I_nu]  delta_nu;
-  vector<lower=-5,upper=0>[K-1]   tau_raw[I];
+  array[I] vector<lower=-5,upper=0>[K-1]   tau_raw;
 
-  vector[trait] theta[J];
+  array[J] vector[trait] theta;
   cholesky_factor_corr[trait] L_Omega;
   matrix[P,trait] lambda;    // person covariate regression coefficient
 }
@@ -70,7 +70,7 @@ transformed parameters{
 
   vector[I_NN] delta1;
   vector[I] delta;
-  vector[K] tau[I];
+  array[I] vector[K] tau;
 
   delta1=append_row(delta_ng,delta_nu);
   delta=append_row(delta1,delta_po);


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
